### PR TITLE
Bug fix for multiple "autoMiss == true" Croutons being called rapidly in succession.

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,16 +120,22 @@ module.exports = React.createClass({
     if (typeof message === 'string')
       message = [message];
     var autoMiss = nextProps.autoMiss ? (buttons ? false : true) : nextProps.autoMiss;
-    this.setState({
-      hidden: nextProps.hidden,
-      buttons: buttons,
-      message: message,
-      type: nextProps.type
-    });
     if (autoMiss && !nextProps.hidden) {
       var ttd = setTimeout(this.dismiss, nextProps.timeout || this.props.timeout);
+      this.dismiss();
       this.setState({
-        ttd: ttd
+        ttd: ttd,
+        hidden: nextProps.hidden,
+        buttons: buttons,
+        message: message,
+        type: nextProps.type
+      });
+    } else {
+      this.setState({
+        hidden: nextProps.hidden,
+        buttons: buttons,
+        message: message,
+        type: nextProps.type
       });
     }
   },


### PR DESCRIPTION
I came across a bug while using this at work (thanks for building this component btw!).  I had a Crouton for warning messages that I set to dismiss after 4000 milliseconds.  This Crouton was invoked via click.  I found that if I sent a new message to the Crouton before the old message had disappeared, sometimes this new message would disappear very quickly.  This is reproducable on the live demo.  Simply click on the first "Show" button 5 times really fast, then when the Crouton disappears click again immediately.  The message should flash and then disappear almost instantaneously.

I tried to track down the source of the bug and I believe I found it.  In `this.changeState()`, we update `this.state.ttd` to be a reference to a new timeout without first clearing the old one.  Although we lose the reference to the old timeout, it's callback still fires, which can cause the Crouton to hide itself prematurely:

1. Invoke crouton, callback1 created
2. Invoke crouton again, callback2 created
3. callback1 fires, making crouton disappear
4. Invoke crouton, a split second before callback2 fires.  callback3 created
5. callback2 fires, making crouton disappear prematurely
6. callback3 fires, having no visible effect. 

This can be confirmed on the live demo by putting a breakpoint inside `this.clearTimeout()` and then clicking "Show" several times in rapid succession.  `this.clearTimeout()` will be called once for each click.

The fix I am submitting manually calls `this.dismiss()` before updating `this.state.ttd`.  